### PR TITLE
TempFile, TempDir: Drop handle, add open method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `TempDir`, `TempFile`: Add `open` methods to get an `std.fs.Dir` or
+  `std.fs.File` for the temporary artifact.
+
+### Changed
+- `TempDir`, `TempFile`: Replace `close` with `deinit`.
+
+### Removed
+- `TempDir`: Drop `dir` field. The `open` method should be used instead.
+- `TempFile`: Drop `file` field. The `open` method should be used instead.
+
 ## 0.1.0
 
 This is the first release of this library.


### PR DESCRIPTION
Drops the `file` or `dir` handle from the `Temp*` types,
replacing them with an `open` method on each.

This puts the responsibility of opening and closing the file or
directory handle on the caller, ensuring that we're not double-closing a
file that the user already closed.

To prevent confusion between Dir.close and TempDir.close,
the destructors have been renamed to `deinit`.

Resolves #2
