### PR TITLE
Add Zig 0.13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0  # most recent stable
+          version: 0.13.0  # most recent stable
 
       - name: Check formatting
         run: zig fmt --check .
@@ -31,7 +31,7 @@ jobs:
     continue-on-error: ${{ matrix.allow-fail }}
     strategy:
       matrix:
-        zig-version: ['0.12.0']
+        zig-version: ['0.12.0', '0.13.0']
         os: [ubuntu-latest, macos-latest, windows-latest]
         allow-fail: [false]
         include:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /cover
 /zig-cache
+/.zig-cache
 /zig-out

--- a/build.zig
+++ b/build.zig
@@ -43,8 +43,8 @@ pub fn build(b: *std.Build) void {
 
         test_step.dependOn(&run_coverage.step);
     } else {
-        const run_uint_tests = b.addRunArtifact(unit_tests);
-        test_step.dependOn(&run_uint_tests.step);
+        const run_unit_tests = b.addRunArtifact(unit_tests);
+        test_step.dependOn(&run_unit_tests.step);
     }
 
     const docs_step = b.step("docs", "Generate docs.");


### PR DESCRIPTION
This pull-request allows temp.zig to compile with Zig 0.13, while not breaking anything for 0.12.
New `.zig-cache` directory added to gitignore, as well as minor refactoring of build.zig (coverage step was changed due to Zig change).
